### PR TITLE
Implement TypedJsMap.toString().

### DIFF
--- a/lib/src/wrapping/js/typed_js_map.dart
+++ b/lib/src/wrapping/js/typed_js_map.dart
@@ -47,4 +47,5 @@ class TypedJsMap<V> extends TypedJsObject implements Map<String,V> {
   @override int get length => Maps.length(this);
   @override bool get isEmpty => Maps.isEmpty(this);
   @override bool get isNotEmpty => Maps.isNotEmpty(this);
+  @override String toString() => Maps.mapToString(this);
 }

--- a/test/browser_tests.dart
+++ b/test/browser_tests.dart
@@ -304,5 +304,12 @@ main() {
       myMap["a"] = new Person('John', 'Doe');
       expect(myMap["a"].firstname, 'John');
     });
+
+    test('toString', () {
+      final m = new jsw.TypedJsMap<int>.fromJsObject(
+          new js.JsObject.jsify({"a": 1, "b": 2}));
+      final string = m.toString();
+      expect(string, equals("{a: 1, b: 2}"));
+    });
   });
 }


### PR DESCRIPTION
So TypedJsMap becomes even more similar to a regular Map.
Very useful for debugging.

BTW: This comment 
// TODO use jsObject.asDartMap()
is obsolete, eh? AFAICS asDartMap hasn't made it to dart:js.  Any chance for that still?
