### PR TITLE
Fix runtime cast failure in JsObjectAsMap.keys.

### DIFF
--- a/js_wrapping/lib/adapter/js_map.dart
+++ b/js_wrapping/lib/adapter/js_map.dart
@@ -61,7 +61,7 @@ class JsObjectAsMap<V> extends JsInterface with MapMixin<String, V> {
 
   @override
   Iterable<String> get keys =>
-      _obj.callMethod('keys', [_o]) as Iterable<String>;
+      _obj.callMethod('keys', [_o]).map<String>((key) => key);
 
   @override
   bool containsKey(Object key) => _o.hasProperty(key as String);


### PR DESCRIPTION
The array returned from JS interop is always List<dynamic>, so casting
it to Iterable<String> will fail in Dart 2.0.

See: https://github.com/dart-lang/sdk/issues/27223