### PR TITLE
Add generic typing to identityConverter

### DIFF
--- a/js_wrapping/lib/adapter/js_list.dart
+++ b/js_wrapping/lib/adapter/js_list.dart
@@ -26,7 +26,7 @@ class JsList<E> extends JsInterface with ListMixin<E> {
   /// Creates an instance backed by the JavaScript object [o].
   JsList.created(JsArray o, Codec<E, dynamic> codec)
       : _o = o,
-        _codec = codec != null ? codec : const IdentityCodec() as Codec<E,dynamic>,
+        _codec = codec != null ? codec : const IdentityCodec<E>(),
         super.created(o);
 
   @override

--- a/js_wrapping/lib/src/codec_util.dart
+++ b/js_wrapping/lib/src/codec_util.dart
@@ -6,19 +6,19 @@ library js_wrapping.src.codec_util;
 
 import 'dart:convert';
 
-class IdentityCodec extends Codec {
+class IdentityCodec<E> extends Codec<E, E> {
   const IdentityCodec();
 
   @override
-  Converter get decoder => const _IdentityConverter();
+  Converter<E, E> get decoder => const _IdentityConverter();
 
   @override
-  Converter get encoder => const _IdentityConverter();
+  Converter<E, E> get encoder => const _IdentityConverter();
 }
 
-class _IdentityConverter extends Converter {
+class _IdentityConverter<E> extends Converter<E, E> {
   const _IdentityConverter();
 
   @override
-  convert(input) => input;
+  E convert(E input) => input;
 }


### PR DESCRIPTION
The lack of generics was causing a runtime failure when using the
googleMaps API (in particular PlaceResult.AddressComponents.types) [0]

[0] Runtime error: IdentityConverter is not of type Codec<E,dynamic> in strong mode