### PR TITLE
Revert "Add generic typing to identityConverter"

### DIFF
--- a/js_wrapping/lib/adapter/js_list.dart
+++ b/js_wrapping/lib/adapter/js_list.dart
@@ -26,7 +26,7 @@ class JsList<E> extends JsInterface with ListMixin<E> {
   /// Creates an instance backed by the JavaScript object [o].
   JsList.created(JsArray o, Codec<E, dynamic> codec)
       : _o = o,
-        _codec = codec != null ? codec : const IdentityCodec<E>(),
+        _codec = codec != null ? codec : const IdentityCodec() as Codec<E,dynamic>,
         super.created(o);
 
   @override

--- a/js_wrapping/lib/src/codec_util.dart
+++ b/js_wrapping/lib/src/codec_util.dart
@@ -6,19 +6,19 @@ library js_wrapping.src.codec_util;
 
 import 'dart:convert';
 
-class IdentityCodec<E> extends Codec<E, E> {
+class IdentityCodec extends Codec {
   const IdentityCodec();
 
   @override
-  Converter<E, E> get decoder => const _IdentityConverter();
+  Converter get decoder => const _IdentityConverter();
 
   @override
-  Converter<E, E> get encoder => const _IdentityConverter();
+  Converter get encoder => const _IdentityConverter();
 }
 
-class _IdentityConverter<E> extends Converter<E, E> {
+class _IdentityConverter extends Converter {
   const _IdentityConverter();
 
   @override
-  E convert(E input) => input;
+  convert(input) => input;
 }


### PR DESCRIPTION
Reverts a14n/dart-js-wrapping#22

I am sorry for this, the semantics of the analyzer, dartdevc and dart2js are different in subtle ways.

When building dart2js version there is this error[0] on which const X() has no direct equivalent to const X<E>().  new X<E>() would work but I'd rather reanalyze how to fix this before introducing something that could be performance degrading on a js wrapper.

Thanks!

[0]
js_wrapping/lib/adapter/js_list.dart:29:62:
Error: Type variable 'E' can't be used as a constant expression js_wrapping.adapter.list::JsList::E.
        _codec = codec != null ? codec : const IdentityCodec<E>(),
